### PR TITLE
feat: improved create_NVIpkg_skeleton

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features:
 
--
+- `create_NVIpkg_skeleton` now adds "^pkg-name\.Rproj$" and "^man-roxygen$" to ".Rbuildignore".
 
 
 ## Bug fixes:

--- a/R/create_NVIpkg_skeleton.R
+++ b/R/create_NVIpkg_skeleton.R
@@ -96,6 +96,8 @@ create_NVIpkg_skeleton <- function(pkg = stringi::stri_extract_last_words(usethi
   usethis::use_directory(path = "notes", ignore = FALSE)
   # Add files to .Rbuildignore
   usethis::use_build_ignore(files = "notes", escape = TRUE)
+  usethis::use_build_ignore(files = "man-roxygen", escape = TRUE)
+  usethis::use_build_ignore(files = paste0(pkg, ".Rproj"), escape = TRUE)
 
 
   # Add dummy for package level documentation.


### PR DESCRIPTION
create_NVIpkg_skeleton now adds "^pkg-name\.Rproj$" and "^man-roxygen$" to ".Rbuildignore". Updated NEWS with new features.